### PR TITLE
Migrate off pkg_resources to importlib (v0.0.7)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.0.7
+
+### Changed
+- Migrate off `pkg_resources` (removed in setuptools 81) to `importlib.resources`
+  for loading the bundled `sources.geojson`; removed unused `pkg_resources` imports
+  in `__init__.py` and `connection.py`.
+
+No other functional changes since 0.0.6.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 
 setuptools.setup(
     name='terrainy',
-    version='0.0.6',
+    version='0.0.7',
     description='Auto-downloader for global terrain data and satellite imagery',
     long_description="""Library to download a raster of 
     global height data such as a DTM, or satellite imagery for a polygon.""",

--- a/terrainy/__init__.py
+++ b/terrainy/__init__.py
@@ -6,7 +6,6 @@ from rasterio.transform import Affine
 import rasterio.rio.clip
 
 import geopandas as gpd
-import pkg_resources
 import shapely
 from shapely.geometry import box, mapping
 from rasterio.warp import calculate_default_transform, reproject, Resampling

--- a/terrainy/connection.py
+++ b/terrainy/connection.py
@@ -14,7 +14,6 @@ import numpy as np
 from shapely.geometry import Polygon
 from owslib.wcs import WebCoverageService
 from owslib.wms import WebMapService
-import pkg_resources
 import importlib.metadata
 import shapely
 import json

--- a/terrainy/sources.py
+++ b/terrainy/sources.py
@@ -1,14 +1,14 @@
 import geopandas as gpd
 import pandas as pd
 import os.path
-import pkg_resources
+from importlib.resources import files
 import traceback
 from . import connection 
 
 sources_path = os.path.expanduser("~/.config/terrainy/sources.geojson")
 
 def load():
-    with pkg_resources.resource_stream("terrainy", "sources.geojson") as f:
+    with files("terrainy").joinpath("sources.geojson").open("rb") as f:
         sources = gpd.read_file(f).set_index("title")
     if os.path.exists(sources_path):
         with open(sources_path, "rb") as f:


### PR DESCRIPTION
Part of emerald-geomodelling/emerald-installer#19. Replaces `pkg_resources.resource_stream` with `importlib.resources.files(...).open('rb')` (binary stream, verified drop-in equivalent). Version bump to 0.0.7 + CHANGES. setuptools>=81 dropped pkg_resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)